### PR TITLE
yucao24hours のプロフィールを更新(第43回)

### DIFF
--- a/members/yucao24hours.md
+++ b/members/yucao24hours.md
@@ -46,4 +46,4 @@ JavaScript をがんばったので素養はちょっとついた気がする!!
 ※… 前月末と当月末の比較。さすがに実値ははずかしかった :flushed: ←本気度とは
 
 
-[しゅくだいアーカイブス](https://gist.github.com/yucato/9353b1a818a1c94d71ff)
+[しゅくだいアーカイブス](https://gist.github.com/yucao24hours/9353b1a818a1c94d71ff)


### PR DESCRIPTION
# ブランチの概要
- ステータスを上げたときのコメントを消した
- 過去のシュクダイを Gist に移動した
- その Gist の URL のアカウントが古いままだったので書き換えた
- 2014年の進捗を更新
