### PR TITLE
"master ブランチに直接 push しようとしたら中断させる仕組み" を導入するスクリプトを作りました

### DIFF
--- a/scripts/update_pre_push/pre-push.sample
+++ b/scripts/update_pre_push/pre-push.sample
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# pre-push hook to prevent direct pushing to master excluding the following cases
+# - All commit logs for the commits to be pushed start with "[ALLOW_MASTER]"
+# e.g [ALLOW_MASTER] Fix something
+# https://gist.github.com/5t111111/7779f7ac2c844c1b5479
+
+z40=0000000000000000000000000000000000000000
+
+while read local_ref local_sha1 remote_ref remote_sha1
+do
+  if [ "${remote_ref##refs/heads/}" = "master" ]; then
+    if [ "$remote_sha1" = $z40 ]; then
+      # New branch, examine all commits
+      range="$local_sha1"
+    else
+      # Update to existing branch, examine new commits
+      range="$remote_sha1..$local_sha1"
+    fi
+
+    # Check for non-allow-master commits
+    commit=`git rev-list --invert-grep --grep '^\[ALLOW_MASTER\]' "$range"`
+    if [ -n "$commit" ]; then
+      cat << EOT
+=============================================================================
+Pushing to the commits the master branch is not allowed
+if there exists at least 1 commit log that doesn't start with [ALLOW_MASTER]
+=============================================================================
+EOT
+      exit 1
+    fi
+  fi
+done
+
+exit 0

--- a/scripts/update_pre_push/update_pre_push.rb
+++ b/scripts/update_pre_push/update_pre_push.rb
@@ -1,0 +1,14 @@
+require 'open-uri'
+
+# TODO 以下はダミーなので、差し替える https://raw.githubusercontent.com/yochiyochirb/meetups/master/scripts/update_pre_push/pre-push.sample
+SCRIPT_URI = 'https://raw.githubusercontent.com/yochiyochirb/meetups/master/members/yucao24hours.md'
+
+File.open('.git/hooks/pre-push', 'a') do |f|
+  begin
+    f.write open(SCRIPT_URI).read
+    f.chmod 0755
+    puts 'Your pre-push hook ("./.git/hooks/pre-push") has been successfully updated!'
+  rescue => e
+    puts "An error occurred while updating your pre-push hook.\n#{e}"
+  end
+end


### PR DESCRIPTION
## やったこと

ユーザが master ブランチに直接 push できないようにする制御処理を、ユーザ自身のローカル環境に導入するためのスクリプトを作りました。

```sh
$ ruby scripts/update_pre_push/update_pre_push.rb
```

を実行するだけで :ok: なようになっています（なります）。

## 背景

この meetups リポジトリでは原則として、master ブランチへ直接 push するような運用はしていただかないようにお願いしています。
なぜなら、master ブランチにあるファイルはわたしたち全員の共有すべき持ち物であり資産ですので、直接いじらずにまずはトピックブランチで作業をし Pull Request によるレビューを経て、キレイな状態にしてからマージしていきたいからです。
そのため、万が一 master に向けて push をしようとしてしまったときに、それを未然に防ぐための仕組みを取り入れたいと思い、今回の PR を作成しました。

## 作成したファイルについて

:bulb:`scripts/update_pre_push/pre-push.sample` には、Git で `git push` をした際に呼ばれる [pre-push hook](https://git-scm.com/book/ja/v2/Git-%E3%81%AE%E3%82%AB%E3%82%B9%E3%82%BF%E3%83%9E%E3%82%A4%E3%82%BA-Git-%E3%83%95%E3%83%83%E3%82%AF#クライアントサイドフック) と呼ばれる仕組みを使って、__ユーザが master ブランチに向けて push しようとしている場合はエラーメッセージを出力して push を中断させる__という処理が記述されています。こちらのスクリプトは @5t111111 さんが作ってくださいました :confetti_ball: :bow: 
（`[ALLOW_MASTER]` という文字列からはじまるコミットメッセージのコミットを含む場合のみ、中断させずに push ができます。ただしこちらはコミュニティ運営用として使うことを前提にしているため、通常の操作では使わない運用とします。）

:bulb:`scripts/update_pre_push/update_pre_push.rb` を実行すると、上記のスクリプト内容をユーザ自身のローカル環境にある .git/hooks/pre-push に追記し、実行可能な状態にします。

:bulb:ユーザのみなさんが使っていらっしゃる PC の環境に関係なく実行できる状態にしたかったので、シェルスクリプト実行ではなくあえて Ruby によるスクリプトを作成しました。

## 対応ストーリー

connects to #1203 