### PR TITLE
Re: "master ブランチに直接 push しようとしたら中断させる仕組み" を導入するスクリプトを作りました

### DIFF
--- a/scripts/update_pre_push/Gemfile
+++ b/scripts/update_pre_push/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "minitest"
+gem "minitest-stub_any_instance"

--- a/scripts/update_pre_push/Gemfile.lock
+++ b/scripts/update_pre_push/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    minitest (5.8.4)
+    minitest-stub_any_instance (1.0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  minitest
+  minitest-stub_any_instance
+
+BUNDLED WITH
+   1.11.2

--- a/scripts/update_pre_push/README.md
+++ b/scripts/update_pre_push/README.md
@@ -1,0 +1,63 @@
+## update_pre_push
+
+ユーザが master ブランチに直接 push できないようにする制御処理を、ユーザ自身のローカル環境に導入するためのスクリプトです。
+
+meetups/ ディレクトリで
+
+```text
+$ ruby scripts/update_pre_push/update_pre_push.rb
+```
+
+を実行すると、ローカルの Git リポジトリに pre-push フックが設定され、master へ直接 push できなくなります。
+
+## 仕様
+
+- pre-push フックを設定すると、master ブランチに直接 push しようとしたとき、以下のエラーメッセージが出て push に失敗します  
+  `Pushing to the commits the master branch is not allowed`
+- もし `git` コマンドがインストールされていなかったりパスが通っていない場合、スクリプトの実行で以下のエラーとなります  
+  `ERROR: Failed to run git command. Check if git is installed and the excutable path is correctly set in PATH.`
+- スクリプトを実行するのが `meetups/` ディレクトリ以外の場合も期待通りにスクリプトが動作し、正しく pre-push が更新されます
+- もし既存の pre-push フックがあった場合、以下の質問に `y` or `yes` (大文字小文字区別なし) と入力した場合のみ、pre-push ファイルが上書きされます  
+  ```text
+  WARN: pre-push file already exists (path/to/existing/pre-push).
+  Are you sure you want to overwrite it? (y/n)
+  ```
+
+### 管理者向け
+
+```text
+$ ruby scripts/update_pre_push/update_pre_push.rb admin
+```
+
+と引数に `admin` をつけてスクリプトを実行すると、管理者向けに pre-push フックが構成され、以下の機能が有効になります。
+
+- `[ALLOW_MASTER]` という文字列からはじまるコミットメッセージのコミットだけを含む場合のみ、中断させずに push ができる
+
+## 必要環境
+
+- Git 1.8.2 以上 (pre-push フックを利用するため)
+- Ruby 1.9 以上
+- git コマンドへのパスが通っていること
+
+### 管理者向け
+
+管理者向けの機能を利用する場合は、Git 2.4 以上が必要になります (`--invert-grep` オプションを使うため) 。
+
+## 動作確認
+
+以下の環境で動作確認を行いました。
+
+- OS X El Capitan 10.11.2  
+  - Git 2.7.0
+  - Ruby 2.3.0
+- Windows 10 Pro x64  
+  - Git 2.7.0.windows.1
+  - Ruby 2.2.3
+- Ubuntu Server 14.04 (管理者向けの動作は未確認)  
+  - Git 1.9.1
+  - Ruby 1.9.3p484
+
+## その他
+
+- テストを実行する場合は `bundle install` してから `update_pre_push_test.rb` を実行してください
+- pre-push ファイルは `pre-push.erb` テンプレートから構成されます。変更したい場合はテンプレートに修正を加えてください

--- a/scripts/update_pre_push/template/pre-push.erb
+++ b/scripts/update_pre_push/template/pre-push.erb
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+<%- if admin -%>
+# pre-push hook to prevent direct pushing to master excluding the following cases
+# - All commit logs for the commits to be pushed start with "[ALLOW_MASTER]"
+# e.g [ALLOW_MASTER] Fix something
+<%- else -%>
+# pre-push hook to prevent direct pushing to master
+<%- end -%>
+# https://gist.github.com/5t111111/7779f7ac2c844c1b5479
+
+z40=0000000000000000000000000000000000000000
+
+while read local_ref local_sha1 remote_ref remote_sha1
+do
+  if [ "${remote_ref##refs/heads/}" = "master" ]; then
+    if [ "$remote_sha1" = $z40 ]; then
+      # New branch, examine all commits
+      range="$local_sha1"
+    else
+      # Update to existing branch, examine new commits
+      range="$remote_sha1..$local_sha1"
+    fi
+
+    <%- if admin -%>
+    # Check for non-allow-master commits
+    commit=`git rev-list --invert-grep --grep '^\[ALLOW_MASTER\]' "$range"`
+    if [ -n "$commit" ]; then
+      cat << EOT
+=============================================================================
+Pushing commits directly to master branch is not allowed
+unless there exists at least 1 commit log that starts with [ALLOW_MASTER]
+=============================================================================
+EOT
+      exit 1
+    fi
+    <%- else -%>
+    cat << EOT
+=============================================================================
+Pushing commits directly to master branch is not allowed
+=============================================================================
+EOT
+    exit 1
+    <%- end -%>
+  fi
+done
+
+exit 0

--- a/scripts/update_pre_push/test/update_pre_push_test.rb
+++ b/scripts/update_pre_push/test/update_pre_push_test.rb
@@ -1,0 +1,104 @@
+require 'minitest/autorun'
+require 'minitest/stub_any_instance'
+require_relative '../update_pre_push.rb'
+
+include PrePushUpdater
+
+class TestPrePushUpdater < Minitest::Test
+  def setup
+    @pre_push_file = File.join(File.dirname($PROGRAM_NAME), 'pre_push.test')
+    @template_file = File.join(File.expand_path(File.join(File.dirname($PROGRAM_NAME), '..')), 'template', 'pre-push.erb')
+  end
+
+  def teardown
+    File.delete(@pre_push_file) if File.exist?(@pre_push_file)
+  end
+
+  def test_check_if_git_command_exist_returns_true_if_exist
+    Object.stub_any_instance(:call_git_version, -> { return 0, '' }) do
+      assert check_if_git_command_exist
+    end
+  end
+
+  def test_check_if_git_command_exist_returns_true_if_does_not_exist
+    Object.stub_any_instance(:call_git_version, -> { return 127, '' }) do
+      refute check_if_git_command_exist
+    end
+  end
+
+  def test_git_directory_returns_expected_directory
+    Object.stub_any_instance(:call_git_rev_parse_git_dir, -> { return 0, "/repo/.git\n" }) do
+      assert_equal '/repo/.git', git_directory
+    end
+  end
+
+  def test_git_directory_returns_nil_when_command_exited_with_failure
+    Object.stub_any_instance(:call_git_rev_parse_git_dir, -> { return 1, '' }) do
+      assert_nil git_directory
+    end
+  end
+
+  def test_git_version_returns_expected_version_when_generic_git
+    Object.stub_any_instance(:call_git_version, -> { return 0, 'git version 2.6.4' }) do
+      assert_equal '2.6.4', git_version
+    end
+  end
+
+  def test_git_version_returns_expected_version_when_apple_git
+    Object.stub_any_instance(:call_git_version, -> { return 0, 'git version 2.5.4 (Apple Git-61)' }) do
+      assert_equal '2.5.4', git_version
+    end
+  end
+
+  def test_git_version_returns_expected_version_when_windows_git
+    Object.stub_any_instance(:call_git_version, -> { return 0, 'git version 2.6.4.windows.1' }) do
+      assert_equal '2.6.4.windows.1', git_version
+    end
+  end
+
+  def test_git_version_returns_nil_when_command_exited_with_failure
+    Object.stub_any_instance(:call_git_version, -> { return 1, '' }) do
+      assert_nil git_version
+    end
+  end
+
+  def test_valid_version_returns_true_when_2_4
+    assert valid_version?('2.4')
+  end
+
+  def test_valid_version_returns_true_when_2_4_1
+    assert valid_version?('2.4.1')
+  end
+
+  def test_valid_version_returns_true_when_22_44_11
+    assert valid_version?('22.44.11')
+  end
+
+  def test_valid_version_returns_false_when_2_3_99
+    refute valid_version?('2.3.99')
+  end
+
+  def test_valid_version_returns_false_when_1_8
+    refute valid_version?('1.8')
+  end
+
+  def test_valid_version_returns_false_when_1
+    refute valid_version?('1')
+  end
+
+  def test_update_pre_push_file_create_expected_file_with_admin_flag
+    update_pre_push_file(@template_file, @pre_push_file, true)
+    content = File.open(@pre_push_file).read
+    assert content.include?('unless there exists at least 1 commit log that starts with')
+  end
+
+  def test_update_pre_push_file_create_expected_file_without_admin_flag
+    update_pre_push_file(@template_file, @pre_push_file, false)
+    content = File.open(@pre_push_file).read
+    refute content.include?('unless there exists at least 1 commit log that starts with')
+  end
+
+  def test_update_pre_push_file_returns_false_on_failure
+    refute update_pre_push_file('notexist', @pre_push_file, false)
+  end
+end

--- a/scripts/update_pre_push/update_pre_push.rb
+++ b/scripts/update_pre_push/update_pre_push.rb
@@ -1,0 +1,114 @@
+require 'erb'
+
+module PrePushUpdater
+  # Wrap `git rev-parse --git-dir`
+  def call_git_rev_parse_git_dir
+    result = `git rev-parse --git-dir`
+    return $?.exitstatus, result
+  rescue => e # A workaround for Windows
+    STDERR.puts e
+    return 127, ''
+  end
+
+  # Wrap `git --version`
+  def call_git_version
+    result = `git --version`
+    return $?.exitstatus, result
+  rescue => e # A workaround for Windows
+    STDERR.puts e
+    return 127, ''
+  end
+
+  def check_if_git_command_exist
+    status, _result = call_git_version
+    status == 0
+  end
+
+  # Get .git directory
+  def git_directory
+    return @git_directory if @git_directory
+    status, result = call_git_rev_parse_git_dir
+    return nil unless status == 0
+    @git_directory = result.chomp
+  end
+
+  # Get Git version
+  def git_version
+    return @git_version if @git_version
+    status, result = call_git_version
+    return nil unless status == 0
+    version_array = result.split.select { |s| s.match(/\A\d+\.\d+\.?\d*.*\Z/) }
+    return nil if version_array.empty?
+    @git_version = version_array.first
+  end
+
+  # Check if Git version is greater than or equal to 2.4
+  # as --invert-grep does not work on 2.3 or below.
+  def valid_version?(version)
+    Gem::Version.new(version) >= Gem::Version.new('2.4')
+  end
+
+  # Update pre
+  def update_pre_push_file(template_file, destination_file, admin = false)
+    erb = ERB.new(File.open(template_file).read, nil, '-')
+    result = erb.result(binding)
+
+    File.open(destination_file, 'w') do |f|
+      f.write(result)
+      f.chmod(0755)
+    end
+  rescue => e
+    STDERR.puts e
+    false
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  include PrePushUpdater
+
+  if ARGV[0] == 'admin'
+    puts "INFO: pre-push hook will be updated as administrator version."
+    admin_flag = true
+  end
+
+  unless check_if_git_command_exist
+    STDERR.puts 'ERROR: Failed to run git command. Check if git is installed and the excutable path is correctly set in PATH.'
+    exit 1
+  end
+
+  previous_wd = Dir.getwd
+  at_exit { Dir.chdir(previous_wd) }
+  Dir.chdir(File.dirname($PROGRAM_NAME))
+
+  unless git_directory
+    STDERR.puts 'ERROR: Failed to get .git directory. Are you sure you are in a Git repository?'
+    exit 1
+  end
+
+  if admin_flag && !git_version
+    STDERR.puts 'ERROR: Failed to get git version.'
+    exit 1
+  end
+
+  if admin_flag && !valid_version?(git_version)
+    STDERR.puts 'ERROR: Git version must be greater than or equal to 2.4. Please upgrade Git before updating a pre-push hook.'
+    exit 1
+  end
+
+  pre_push_file = File.join(git_directory, 'hooks', 'pre-push')
+
+  if File.exist?(pre_push_file)
+    puts "WARN: pre-push file already exists (#{pre_push_file}).\nAre you sure you want to overwrite it? (y/n)"
+    s = $stdin.gets.chomp
+    exit unless s.match(/\Ay\Z/i) || s.match(/\Ayes\Z/i)
+  end
+
+  pre_push_template_file = File.join('template', 'pre-push.erb')
+
+  unless update_pre_push_file(pre_push_template_file, pre_push_file, admin_flag)
+    STDERR.puts 'An error occurred while updating your pre-push hook.'
+    exit 1
+  end
+
+  puts "Your pre-push hook (#{pre_push_file}) has been successfully updated!"
+end


### PR DESCRIPTION
## やったこと

ユーザが master ブランチに直接 push できないようにする制御処理を、ユーザ自身のローカル環境に導入するためのスクリプトを作りました。
※ #1282 のスクリプトを改善したものです。

meetups/ ディレクトリで

```text
$ ruby scripts/update_pre_push/update_pre_push.rb
```

を実行すると、ローカルの Git リポジトリに pre-push フックが設定され、master へ直接 push できなくなります。

## 仕様

- pre-push フックを設定すると、master ブランチに直接 push しようとしたとき、以下のエラーメッセージが出て push に失敗します  
  `Pushing to the commits the master branch is not allowed`
- もし `git` コマンドがインストールされていなかったりパスが通っていない場合、スクリプトの実行で以下のエラーとなります  
  `ERROR: Failed to run git command. Check if git is installed and the excutable path is correctly set in PATH.`
- スクリプトを実行するのが `meetups/` ディレクトリ以外の場合も期待通りにスクリプトが動作し、正しく pre-push が更新されます
- もし既存の pre-push フックがあった場合、以下の質問に `y` or `yes` (大文字小文字区別なし) と入力した場合のみ、pre-push ファイルが上書きされます  
  ```text
  WARN: pre-push file already exists (path/to/existing/pre-push).
  Are you sure you want to overwrite it? (y/n)
  ```

### 管理者向け

```text
$ ruby scripts/update_pre_push/update_pre_push.rb admin
```

と引数に `admin` をつけてスクリプトを実行すると、管理者向けに pre-push フックが構成され、以下の機能が有効になります。

- `[ALLOW_MASTER]` という文字列からはじまるコミットメッセージのコミットだけを含む場合のみ、中断させずに push ができる

## 必要環境

- Git 1.8.2 以上 (pre-push フックを利用するため)
- Ruby 1.9 以上
- git コマンドへのパスが通っていること

### 管理者向け

管理者向けの機能を利用する場合は、Git 2.4 以上が必要になります (`--invert-grep` オプションを使うため) 。

## 動作確認

以下の環境で動作確認を行いました。

- OS X El Capitan 10.11.2  
  - Git 2.7.0
  - Ruby 2.3.0
- Windows 10 Pro x64  
  - Git 2.7.0.windows.1
  - Ruby 2.2.3
- Ubuntu Server 14.04 (管理者向けの動作は未確認)  
  - Git 1.9.1
  - Ruby 1.9.3p484

## その他

- テストを実行する場合は `bundle install` してから `update_pre_push_test.rb` を実行してください
- pre-push ファイルは `pre-push.erb` テンプレートから構成されます。変更したい場合はテンプレートに修正を加えてください
